### PR TITLE
build: docker v7

### DIFF
--- a/docker-files/image-attributes.sh
+++ b/docker-files/image-attributes.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 dockerImage="plutus-certification-web"
-imageTag="6"
+imageTag="7"


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the Docker image tag in the `image-attributes.sh` script from "6" to "7". This change will ensure that the latest version of the Docker image is used during deployments or local development, providing users with the most recent updates and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->