### PR TITLE
feat: switch to stake-address & Yoroi support (PLT-7455)

### DIFF
--- a/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/components/ConnectWallet/ConnectWallet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { Address } from "@emurgo/cardano-serialization-lib-browser";
+import { Address,BaseAddress,RewardAddress } from "@emurgo/cardano-serialization-lib-browser";
 import { useAppDispatch } from "store/store";
 import { getProfileDetails, logout, setNetwork } from "store/slices/auth.slice";
 
@@ -20,13 +20,38 @@ declare global {
     cardano: any;
   }
 }
+
+// hex string
+export type StakeAddressHex = string;
+export type StakeAddressBech32 = `stake${string}`;
+export type ChangeAddressBech32 = `addr${string}`;
+
+export const getAddresses = async (wallet: any): Promise<[StakeAddressHex, StakeAddressBech32,ChangeAddressBech32]> => {
+  const networkId = await wallet.getNetworkId();
+  const changeAddrHex = await wallet.getChangeAddress();
+
+  // derive the stake address from the change address to be sure we are getting
+  // the stake address of the currently active account.
+  const changeAddress = Address.from_bytes( Buffer.from(changeAddrHex, 'hex') );
+  const baseChangeAddress = BaseAddress.from_address(changeAddress);
+  if(!baseChangeAddress) throw new Error(`Could not derive base address from change address: ${changeAddrHex}`)
+  const stakeCredential = baseChangeAddress?.stake_cred();
+  if(!stakeCredential) throw new Error(`Could not derive stake credential from change address: ${changeAddrHex}`)
+  const stakeAddress = RewardAddress.new(networkId, stakeCredential).to_address();
+
+  return [
+    stakeAddress.to_hex(),
+    stakeAddress.to_bech32() as StakeAddressBech32,
+    baseChangeAddress.to_address().to_bech32() as ChangeAddressBech32
+  ];
+}
 let CardanoNS = window.cardano;
 
 const ConnectWallet = () => {
   const dispatch = useAppDispatch();
   const [wallet, setWallet] = useState(null);
   const [walletName, setWalletName] = useState("");
-  const [address, setAddress] = useState("");
+  const [address, setAddress] = useState(null as ChangeAddressBech32 | null)
   const [isOpen, setIsOpen] = useState(false);
   const [errorToast, setErrorToast] = useState<{display: boolean; statusText?: string; message?: string; showRetry?: boolean}>({display: false});
   const [walletLoading, setWalletLoading] = useState(false);
@@ -61,11 +86,8 @@ const ConnectWallet = () => {
         setWallet(enabledWallet);
         setWalletName(walletName);
         if (enabledWallet) {
-          const response = await enabledWallet.getChangeAddress();
-          const walletAddr = Address.from_bytes(
-            Buffer.from(response, "hex")
-          ).to_bech32();
-          initiatePrivateWalletSignature(enabledWallet, walletAddr, response);
+          const [stakeAddrHex, stakeAddrBech32,changeAddress] = await getAddresses(enabledWallet);
+          initiatePrivateWalletSignature(enabledWallet,  stakeAddrBech32, stakeAddrHex,changeAddress);
         }
       });
     } catch (e) {
@@ -76,13 +98,13 @@ const ConnectWallet = () => {
   const handleError = (error: any) => {
     if (error.info) {
       setErrorToast({
-          display: true, 
-          message: error.info, 
+          display: true,
+          message: error.info,
           showRetry: error.code === 3})
     } else if (error.response) {
         setErrorToast({
-            display: true, 
-            statusText: error.response.statusText, 
+            display: true,
+            statusText: error.response.statusText,
             message: error.response.data || undefined,
             showRetry: error.status === 403
         })
@@ -102,19 +124,24 @@ const ConnectWallet = () => {
     dispatch(logout())
   }
 
-  const initiatePrivateWalletSignature = async (currentWallet: any, walletAddr_bech32: any, walletAddr: string) => {
+  const initiatePrivateWalletSignature = async (
+    currentWallet: any,
+    stakeAddressBech32: StakeAddressBech32,
+    stakeAddressHex: StakeAddressHex,
+    changeAddressBech32: ChangeAddressBech32
+  ) => {
     const timestamp = (await fetchData.get<any,AxiosResponse<number>,any>('/server-timestamp')).data;
-    const msgToBeSigned = `Sign this message if you are the owner of the ${walletAddr_bech32} address. \n Timestamp: <<${timestamp}>> \n Expiry: 60 seconds`;
+    const msgToBeSigned = `Sign this message if you are the owner of the ${changeAddressBech32} address. \n Timestamp: <<${timestamp}>> \n Expiry: 60 seconds`;
     try {
-        const {key, signature} = await currentWallet.signData(walletAddr, Buffer.from(msgToBeSigned, 'utf8').toString('hex'))
+        const {key, signature} = await currentWallet.signData(stakeAddressHex, Buffer.from(msgToBeSigned, 'utf8').toString('hex'))
         if (key && signature) {
             const token = (await fetchData.post<any,AxiosResponse<string>,any>('/login', {
-                address: walletAddr_bech32,
+                address: stakeAddressBech32,
                 key: key,
                 signature: signature
             })).data;
             localStorage.setItem(LocalStorageKeys.authToken, token)
-            setAddress(walletAddr_bech32)
+            setAddress(changeAddressBech32)
         } else {
             catchError({ message: "Could not obtain the proper key and signature for the wallet. Please try connecting again." })
         }
@@ -130,6 +157,7 @@ const ConnectWallet = () => {
           const response: any = await dispatch(
             getProfileDetails({
               address: address,
+              stakeAddress: address,
               wallet: wallet,
               walletName: walletName,
             })

--- a/src/components/CreateCertificate/CreateCertificate.tsx
+++ b/src/components/CreateCertificate/CreateCertificate.tsx
@@ -33,7 +33,7 @@ interface Certificate {
 const CreateCertificate = () => {
     const dispatch = useDispatch();
     const { uuid } = useAppSelector((state) => state.certification);
-    const { address, wallet } = useAppSelector((state) => state.auth);
+    const { address, wallet,userDetails:{address: payer} } = useAppSelector((state) => state.auth);
     const [ certifying, setCertifying ] = useState(false);
     const [ certified, setCertified ] = useState(false);
     const [ transactionId, setTransactionId ] = useState("")
@@ -106,7 +106,7 @@ const CreateCertificate = () => {
     const triggerSubmitCertificate = async (txnId?: string) => {
         fetchData.post('/run/' + uuid + '/certificate' + (txnId ? '?transactionid=' + txnId : ''))
             .catch(handleError)
-            .then((response: any) => {
+            .then(() => {
                 fetchRunDetails(txnId)
             })
     }
@@ -116,7 +116,7 @@ const CreateCertificate = () => {
         setShowError("")
         if (performTransaction) {
             const response = await dispatch(
-                payFromWallet({ fee: BigNum.from_str(certificationPrice.toString()), wallet: wallet, address: address })
+                payFromWallet({ fee: BigNum.from_str(certificationPrice.toString()), wallet, address, payer, })
             );
             if (response.payload) {
                 triggerSubmitCertificate(response.payload)

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, memo, useCallback } from "react";
 import { Link } from "react-router-dom";
-import { Address } from "@emurgo/cardano-serialization-lib-browser";
 import { useAppDispatch, useAppSelector } from "store/store";
 import {
   logout,
@@ -13,13 +12,13 @@ import "./Header.scss";
 import { useDelayedApi } from "hooks/useDelayedApi";
 import { fetchData } from "api/api";
 import useLocalStorage from "hooks/useLocalStorage";
-import ConnectWallet from "components/ConnectWallet/ConnectWallet";
+import ConnectWallet,{getAddresses} from "components/ConnectWallet/ConnectWallet";
 import AvatarDropDown from "components/AvatarDropdown/AvatarDropdown";
 import DropoverMenu from "components/DropoverMenu/DropoverMenu";
 import { LocalStorageKeys } from 'constants/constants';
 
 const Header = () => {
-  const { isLoggedIn, address, wallet, network } = useAppSelector(
+  const { isLoggedIn, address, wallet, network, userDetails: { address: stakeAddress } } = useAppSelector(
     (state) => state.auth
   );
   const dispatch = useAppDispatch();
@@ -96,9 +95,9 @@ const Header = () => {
   // }, [isLoggedIn]);
 
   useEffect(() => {
-    setPollForAddress(wallet && address && isLoggedIn);
-    setPollForNetwork(wallet && address && isLoggedIn && network !== null);
-  }, [wallet, address, isLoggedIn, network]);
+    setPollForAddress(wallet && stakeAddress && isLoggedIn);
+    setPollForNetwork(wallet && stakeAddress && isLoggedIn && network !== null);
+  }, [wallet, stakeAddress, isLoggedIn, network]);
 
   const forceUserLogout = () => {
     // account/network has been changed. Force logout the user
@@ -112,14 +111,17 @@ const Header = () => {
   useDelayedApi(
     async () => {
       setPollForAddress(false);
-      let newAddress = "";
+      let newStakeAddress = "";
+      let newAddress = ""
       if (wallet) {
-        const response = await wallet.getChangeAddress().catch((e: any) => console.error('Failed to get change address:', e));
-        newAddress = Address.from_bytes(
-          Buffer.from(response, "hex")
-        ).to_bech32();
+        newStakeAddress = (await getAddresses(wallet))[1];
+        newAddress = (await getAddresses(wallet))[2];
       }
+
       if (newAddress && address !== newAddress) {
+         localStorage.setItem(LocalStorageKeys.address, newAddress)
+      }
+      if (newStakeAddress && stakeAddress !== newStakeAddress) {
         forceUserLogout();
       } else {
         setPollForAddress(true);
@@ -192,18 +194,18 @@ const Header = () => {
       <>
         <li>
           <Link to="support">Support</Link>
-        </li>        
+        </li>
         <li>
           <Link to="subscription">Subscription</Link>
         </li>
         {featureList.indexOf('l2-upload-report') !== -1 ? (
           <li>
-            <DropoverMenu 
-              name="auditing" 
+            <DropoverMenu
+              name="auditing"
               mainElm={<AuditMainMenu />}
               listItems={<AuditSubMenu />}></DropoverMenu>
-            
-            
+
+
           </li>
         ) : null}
         <li>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,10 +1,14 @@
 export const LocalStorageKeys = {
-    "profile": "profile",
-    "isLoggedIn": "isLoggedIn",
-    "userDetails": "userDetails",
-    "walletName": "walletName",
-    "address": "address",
-    "authToken": "authToken",
-    "accessToken": "accessToken",
-    "hasSubscriptions": "hasSubscriptions"
+  profile: "profile",
+  isLoggedIn: "isLoggedIn",
+  userDetails: "userDetails",
+  walletName: "walletName",
+  address: "address",
+  authToken: "authToken",
+  accessToken: "accessToken",
+  hasSubscriptions: "hasSubscriptions",
+  certificationUuid: "certificationUuid",
+  certificationRunTime: "certificationRunTime",
+  certificationDone: "certificationDone",
+  commit: "commit"
 };

--- a/src/pages/subscription/payment/Payment.tsx
+++ b/src/pages/subscription/payment/Payment.tsx
@@ -3,7 +3,7 @@ import { fetchData } from "api/api";
 import Button from "components/Button/Button";
 import Modal from "components/Modal/Modal";
 import Toast from "components/Toast/Toast";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 import { payFromWallet } from "store/slices/walletTransaction.slice";
@@ -16,7 +16,9 @@ function Payment() {
   const { state } = useLocation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const { address, wallet } = useAppSelector((state) => state.auth);
+  const { address, wallet,userDetails: {address: payer} } = useAppSelector((state) => {
+    return state.auth
+  });
   const { error } = useAppSelector((state) => state.walletTransaction);
   const [transactionId, setTransactionId] = useState("");
   const [showError, setShowError] = useState("");
@@ -91,7 +93,7 @@ function Payment() {
 
   const triggerTransactionFromWallet = async (fee_in_lovelace: BigNum) => {
     const response = await dispatch(
-      payFromWallet({ fee: fee_in_lovelace, wallet: wallet, address: address })
+      payFromWallet({ fee: fee_in_lovelace, wallet, address, payer })
     );
     if (response.payload) {
       setTransactionId(response.payload);
@@ -103,7 +105,7 @@ function Payment() {
 
   const fetchCurrentSubscription = (isAfterPayment?: boolean) => {
     fetchData.get("/profile/current/subscriptions").then((response: {data: Subscription[]}) => {
-      const current: Subscription | undefined = response.data.find((item: Subscription) => item.id === currentSubscriptionId) 
+      const current: Subscription | undefined = response.data.find((item: Subscription) => item.id === currentSubscriptionId)
       if (current && current.tierId === state.id) {
         if (current.status === 'pending') {
           if (isAfterPayment) {
@@ -120,7 +122,7 @@ function Payment() {
           // payment retrieved from balance
           setProcessing(false);
           setOpenModal(true);
-        } 
+        }
       }
     }).catch(handleError);
   }
@@ -141,7 +143,7 @@ function Payment() {
       navigate(-1)
     }
   })
-  
+
   const renderPage = () => {
     return (
     <div className="payment-container">

--- a/src/pages/userProfile/userProfile.interface.ts
+++ b/src/pages/userProfile/userProfile.interface.ts
@@ -1,4 +1,5 @@
 export interface IUserProfile {
+  "address"?: string,
   "authors"?: string,
   "contacts"?: string,
   "dapp": {

--- a/src/store/slices/auth.slice.ts
+++ b/src/store/slices/auth.slice.ts
@@ -30,8 +30,8 @@ const clearLSCache = () => {
 }
 
 export const getProfileDetails: any = createAsyncThunk("getProfileDetails", async (data: any, { rejectWithValue }) => {
-  localStorage.setItem(LocalStorageKeys.address, data.address) 
-  const response = await fetchData.get("/profile/current", data)
+  localStorage.setItem(LocalStorageKeys.address, data.address)
+  const response = await fetchData.get("/profile/current")
   // FOR MOCK - const response = await fetchData.get(data.url || 'static/data/current-profile.json', data)
   return response.data
 })


### PR DESCRIPTION
We found that Yoroi wallet is generating new addresses every-time one is used.

That will create new profiles for each of them

In fact that might become the case in other wallets as well, the solution would be to use the stake address instead the payment address  for login/signing since that should remain unchanged between the same wallet accounts.

Refs: [PLT-7455](https://input-output.atlassian.net/browse/PLT-7455)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added functionality to retrieve stake and change addresses from a wallet in the `ConnectWallet` component.
- Refactor: Updated `payFromWallet` function to accept a `PaymentData` object, improving code readability and maintainability.
- Refactor: Modified `initiatePrivateWalletSignature` function to use stake and change addresses instead of the wallet address, enhancing security.
- New Feature: Added optional "address" field to the `IUserProfile` interface, allowing users to store their address information.
- Refactor: Improved error handling and API calls in `walletTransaction.slice.ts`, enhancing application stability.
- Chore: Added new keys to the `LocalStorageKeys` object for storing certification data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->