### PR TITLE
build: increase docker tag version to 8

### DIFF
--- a/docker-files/image-attributes.sh
+++ b/docker-files/image-attributes.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 dockerImage="plutus-certification-web"
-imageTag="7"
+imageTag="8"


### PR DESCRIPTION
just increasing the docker version tag
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Chore: Updated Docker image tag in the build script. The `imageTag` variable in `docker-files/image-attributes.sh` has been updated from "7" to "8". This change will ensure that the latest version of the Docker image is used during the build process, potentially incorporating new features or bug fixes from the updated image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->