### PR TITLE
[Feat/ FIX] Prefil testing form with details in profile dapp

### DIFF
--- a/src/components/CertificationMetadataForm/utils.ts
+++ b/src/components/CertificationMetadataForm/utils.ts
@@ -177,7 +177,7 @@ export const getResolver= (isReviewCertification?: boolean) => buildFormResolver
 ].filter(field => field !== null) as Field[]);
 
 export const getDefaultValues = (profile: UserProfile | null): ReportForm => ({
-  certificationLevel: '0',
+  certificationLevel: '',
   summary: '',
   disclaimer: '',
   subject: '',

--- a/src/pages/certification/components/AuditorRunTestForm/AuditorRunTestForm.tsx
+++ b/src/pages/certification/components/AuditorRunTestForm/AuditorRunTestForm.tsx
@@ -62,9 +62,15 @@ const AuditorRunTestForm: React.FC<IAuditorRunTestForm> = ({
     mode: "all",
     defaultValues: profile && profile.dapp ? {
       repoURL: profile.dapp.owner && profile.dapp.repo ? `https://github.com/${profile.dapp.owner}/${profile.dapp.repo}` : undefined,
-      name: profile.dapp.name, version: profile.dapp.version,
+      name: profile.dapp.name, 
+      version: profile.dapp.version,
+      subject: profile.dapp.subject,
     } : undefined
   });
+
+  if (profile && profile.dapp) {
+    forceValidate = true
+  }
 
   const checkRepoAccess = (urlValue: string) => {
     if (urlValue) {


### PR DESCRIPTION
https://input-output.atlassian.net/browse/PLT-7822

* Ensure to prefill Testing form with details in profile dapp (repoUrl, name, version?, subject?) always
* Bug Fix - Certification Level dropdown in Auditor Report Upload metadata form doesn't show required error when hit on Submit
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Bug Fix":
- Enhanced the Auditor Run Test Form by adding a new `subject` property to the default values object. This change improves form data handling and ensures that all necessary fields are included in the form submission.
- Improved validation process for the form. Now, if a `dapp` profile exists, the form will enforce validation rules, ensuring data integrity and reducing the chance of submitting incorrect or incomplete information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->