### PR TITLE
[PLT-8338] Edit 'Test again','New test' buttons upon finished test

### DIFF
--- a/src/pages/certification/Certification.tsx
+++ b/src/pages/certification/Certification.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button, CircularProgress } from "@mui/material";
 import LeaderboardIcon from '@mui/icons-material/Leaderboard';
-import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import CommitIcon from '@mui/icons-material/Commit';
 
 import { ellipsizeString } from "utils/utils";
 
@@ -13,8 +13,10 @@ import useLocalStorage from "hooks/useLocalStorage";
 import { IAuditorRunTestFormFields } from "./components/AuditorRunTestForm/auditorRunTestForm.interface";
 
 import './Certification.css';
+import { useAppSelector } from "store/store";
 
 const Certification = () => {
+    const {features} = useAppSelector((state) => state.auth)
     const [lsFormData] = useLocalStorage(LocalStorageKeys.certificationFormData, "");
     const [lsUuid] = useLocalStorage(LocalStorageKeys.certificationUuid, "");
     const [disableForm, setDisableForm] = useState(false);
@@ -104,20 +106,24 @@ const Certification = () => {
                 </h2>
                 {runEnded && (
                     <div className="flex gap-x-4">
-                        <Button
-                            type="button"
-                            variant="contained" size="small"
-                            onClick={triggerRetest}
-                            className="button text-sm min-w-[150px]"
-                            startIcon={<RestartAltIcon />}
-                        >Test again</Button>
-                        <Button
-                            type="button"
-                            variant="contained" size="small"
-                            onClick={triggerNewTest}
-                            className="button text-sm min-w-[150px]"
-                            startIcon={<LeaderboardIcon />}
-                        >New test</Button>
+                        {features.includes('l2-upload-report') && features.includes('l1-run') ? (
+                            <Button
+                                type="button"
+                                variant="contained" size="small"
+                                onClick={triggerRetest}
+                                className="button text-sm min-w-[150px]"
+                                startIcon={<CommitIcon />}
+                            >Test another commit</Button>
+                        ) : null}
+                         {features.includes('l2-upload-report') ? (
+                            <Button
+                                type="button"
+                                variant="contained" size="small"
+                                onClick={triggerNewTest}
+                                className="button text-sm min-w-[150px]"
+                                startIcon={<LeaderboardIcon />}
+                            >Test another DApp</Button>
+                        ): null}
                     </div>
                 )}
             </div>

--- a/src/pages/certification/components/AuditorRunTestForm/AuditorRunTestForm.tsx
+++ b/src/pages/certification/components/AuditorRunTestForm/AuditorRunTestForm.tsx
@@ -58,19 +58,21 @@ const AuditorRunTestForm: React.FC<IAuditorRunTestForm> = ({
   const { profile } = useAppSelector((state) => state.profile);
   const { showConfirmConnection, accessStatus, accessToken, verifying } = useAppSelector((state) => state.repoAccess);
 
-  const form = useForm<IAuditorRunTestFormFields>({
+  const form = useForm<any>({
     resolver, mode: 'all',
     defaultValues: profile && profile.dapp ? {
-      repoURL: profile.dapp.owner && profile.dapp.repo ? `https://github.com/${profile.dapp.owner}/${profile.dapp.repo}` : undefined,
+      repoURL: profile.dapp.owner && profile.dapp.repo ? `https://github.com/${profile.dapp.owner}/${profile.dapp.repo}` : null,
       name: profile.dapp.name, 
       version: profile.dapp.version,
       subject: profile.dapp.subject,
-    } : undefined
+    } : null
   });
 
   const handleRepoFieldBlur = (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    if (event.target.value !== form.getValues().repoURL) {
+    if (event.target.value !== form.getValues().repoURL || event.target.value !== repoUrl) {
       checkRepoAccess(event.target.value);
+    } else if (!event.target.value) {
+      dispatch(clearAccessStatus())
     }
     form.setValue('repoURL', event.target.value);
   }
@@ -91,7 +93,7 @@ const AuditorRunTestForm: React.FC<IAuditorRunTestForm> = ({
       setInitialized(true);
       checkRepoAccess(form.getValues().repoURL);
     }
-  }, [initialized, form.getValues().repoURL]);
+  }, [form.getValues().repoURL]);
 
   useEffect(() => { 
     if (forceValidate) {
@@ -277,22 +279,28 @@ const AuditorRunTestForm: React.FC<IAuditorRunTestForm> = ({
   // New Test: Clear certification form
   useEffect(() => {
     if (clearForm) {
-      form.reset();
       dispatch(clearRepoUrl());
+      const empty = {
+        repoURL: null,
+        commit: null,
+        name: null,
+        version: null,
+        subject: null
+      }
+      form.reset(empty);
+      dispatch(clearAccessStatus())
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clearForm]);
 
   // Test again: Retain repo url in certification form
   useEffect(() => {
-    if (testAgain)
+    if (testAgain) {
       form.reset({
-        repoURL: repoUrl,
-        commit: "",
-        name: "",
-        subject: "",
-        version: "",
+        ...form.getValues(),
+        commit: ""
       });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [testAgain]);
 


### PR DESCRIPTION
https://input-output.atlassian.net/browse/PLT-8338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `Certification` page with new button labels and conditional rendering based on feature flags.
	- Added a `Test another DApp` button to the `Certification` page.
- **Bug Fixes**
	- Improved form handling in the `AuditorRunTestForm` component, including better handling of `repoURL` and resetting of form values.
	- Enhanced user experience by clearing access status and repo URL after certain actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->