### PR TITLE
[PLT-7416] Fix the statistics to the timeline of a test run in FE

### DIFF
--- a/docker-files/image-attributes.sh
+++ b/docker-files/image-attributes.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 dockerImage="plutus-certification-web"
-imageTag="13"
+imageTag="14"

--- a/docker-files/image-attributes.sh
+++ b/docker-files/image-attributes.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 dockerImage="plutus-certification-web"
-imageTag="14"
+imageTag="15"

--- a/src/compositions/Timeline/components/TimelineItem/timeline.helper.tsx
+++ b/src/compositions/Timeline/components/TimelineItem/timeline.helper.tsx
@@ -82,7 +82,10 @@ export const getPlannedTestingTasks = (res: any, _plannedTestingTasks: PlanObj[]
   if (status === "certifying" && state === "running") {
     const resPlan = res.data.plan;
     const resProgress = res.data.progress;
-    if (!plannedTestingTasks.length && resPlan.length) {
+    if (!resPlan || !resProgress) {
+      return []
+    }
+    else if (!plannedTestingTasks.length && resPlan.length) {
       return (
         resPlan.map((item: { index: number; name: string }) => {
           const TaskConfig: ICertificationTask | undefined = CertificationTasks.find((task) => task.name === item.name)

--- a/src/pages/certification/components/TimelineView/TimelineView.tsx
+++ b/src/pages/certification/components/TimelineView/TimelineView.tsx
@@ -199,9 +199,6 @@ const TimelineView: React.FC<Props> = ({ onAbort }) => {
                             Property Name
                           </th>
                           <th scope="col" className="text-center p-2">
-                            Discarded
-                          </th>
-                          <th scope="col" className="text-center p-2">
                             Progress
                           </th>
                         </tr>
@@ -215,9 +212,6 @@ const TimelineView: React.FC<Props> = ({ onAbort }) => {
                             >
                               <td className="whitespace-nowrap p-2">
                                 {task.label}
-                              </td>
-                              <td className="text-center whitespace-nowrap p-2">
-                                {task.discarded}
                               </td>
                               <td className="text-center whitespace-nowrap p-2">
                                 {getTaskProgress(task, index)}

--- a/src/pages/certification/components/TimelineView/TimelineView.tsx
+++ b/src/pages/certification/components/TimelineView/TimelineView.tsx
@@ -181,51 +181,54 @@ const TimelineView: React.FC<Props> = ({ onAbort }) => {
                       result={resultData}
                       coverageFile={coverageFile}
                     />
-                    <ProgressCard 
-                      title={"Property Based Testing"} 
-                      currentValue={calculateCurrentProgress(plannedTestingTasks)} 
-                      totalValue={calculateExpectedProgress(plannedTestingTasks)}
-                    />
+                    {(!plannedTestingTasks || !plannedTestingTasks.length) ? null : (
+                      <ProgressCard 
+                        title={"Property Based Testing"} 
+                        currentValue={calculateCurrentProgress(plannedTestingTasks)} 
+                        totalValue={calculateExpectedProgress(plannedTestingTasks)}
+                      />
+                    )} 
                   </>)}
                 </div>
-
-                <div id="testingProgressContainer" className="mt-20">
-                  <table className="min-w-full text-left text-sm font-light">
-                    <thead className="font-medium dark:border-neutral-500 bg-slate-table-head text-slate-table-headText">
-                      <tr>
-                        <th scope="col" className="p-2">
-                          Property Name
-                        </th>
-                        <th scope="col" className="text-center p-2">
-                          Discarded
-                        </th>
-                        <th scope="col" className="text-center p-2">
-                          Progress
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {plannedTestingTasks.map((task: PlanObj, index: number) => {
-                        return (
-                          <tr
-                            key={task.name}
-                            className="dark:border-neutral-500"
-                          >
-                            <td className="whitespace-nowrap p-2">
-                              {task.label}
-                            </td>
-                            <td className="text-center whitespace-nowrap p-2">
-                              {task.discarded}
-                            </td>
-                            <td className="text-center whitespace-nowrap p-2">
-                              {getTaskProgress(task, index)}
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
+                {(!plannedTestingTasks || !plannedTestingTasks.length) ? null : (  
+                  <div id="testingProgressContainer" className="mt-20">
+                    <table className="min-w-full text-left text-sm font-light">
+                      <thead className="font-medium dark:border-neutral-500 bg-slate-table-head text-slate-table-headText">
+                        <tr>
+                          <th scope="col" className="p-2">
+                            Property Name
+                          </th>
+                          <th scope="col" className="text-center p-2">
+                            Discarded
+                          </th>
+                          <th scope="col" className="text-center p-2">
+                            Progress
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {plannedTestingTasks.map((task: PlanObj, index: number) => {
+                          return (
+                            <tr
+                              key={task.name}
+                              className="dark:border-neutral-500"
+                            >
+                              <td className="whitespace-nowrap p-2">
+                                {task.label}
+                              </td>
+                              <td className="text-center whitespace-nowrap p-2">
+                                {task.discarded}
+                              </td>
+                              <td className="text-center whitespace-nowrap p-2">
+                                {getTaskProgress(task, index)}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </>
             ) : null}
           </>

--- a/src/store/slices/testing.slice.ts
+++ b/src/store/slices/testing.slice.ts
@@ -138,12 +138,6 @@ export const fetchRunStatus = createAsyncThunk("fetchRunStatus", async (payload:
     const { uuid, timelineConfig, plannedTestingTasks, unitTestSuccess, hasFailedTasks, isCustomizedTestingMode } = (thunkApi.getState() as RootState).testing;
     const response:any = await fetch<RunStatus>(thunkApi, { method: 'GET', url: `/run/${uuid}` });
     const newTimelineConfig = processTimeLineConfig(response, timelineConfig);
-    if (response.data.status === "certifying" && response.data.state === "running") {
-      if (!response.data.plan || !response.data.progress) {
-        console.error("Plan and Progress not available in Certifying state");
-        return thunkApi.rejectWithValue("Plan and Progress not available in Certifying state");
-      }
-    }
     let newPlannedTestingTasks = getPlannedTestingTasks(response, plannedTestingTasks, isCustomizedTestingMode);
     if (newPlannedTestingTasks.length === 0 && plannedTestingTasks.length > 0) {
       newPlannedTestingTasks = plannedTestingTasks;

--- a/src/store/slices/testing.slice.ts
+++ b/src/store/slices/testing.slice.ts
@@ -138,13 +138,13 @@ export const fetchRunStatus = createAsyncThunk("fetchRunStatus", async (payload:
     const { uuid, timelineConfig, plannedTestingTasks, unitTestSuccess, hasFailedTasks, isCustomizedTestingMode } = (thunkApi.getState() as RootState).testing;
     const response:any = await fetch<RunStatus>(thunkApi, { method: 'GET', url: `/run/${uuid}` });
     const newTimelineConfig = processTimeLineConfig(response, timelineConfig);
-    let newPlannedTestingTasks = getPlannedTestingTasks(response, plannedTestingTasks, isCustomizedTestingMode);
     if (response.data.status === "certifying" && response.data.state === "running") {
       if (!response.data.plan || !response.data.progress) {
         console.error("Plan and Progress not available in Certifying state");
         return thunkApi.rejectWithValue("Plan and Progress not available in Certifying state");
       }
     }
+    let newPlannedTestingTasks = getPlannedTestingTasks(response, plannedTestingTasks, isCustomizedTestingMode);
     if (newPlannedTestingTasks.length === 0 && plannedTestingTasks.length > 0) {
       newPlannedTestingTasks = plannedTestingTasks;
     }


### PR DESCRIPTION
https://input-output.atlassian.net/browse/PLT-7416

Fixed - Broken UI when `plan` and `progress` missing when `certifying`-`running`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced the Timeline View by conditionally displaying the Progress Card and a testing progress table based on the availability of planned testing tasks.

- **Bug Fixes**
    - Fixed an issue in the timeline helper to prevent errors when planned testing tasks data is not available.
    - Improved error handling in the testing status fetch process to ensure more robust application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->