### PR TITLE
ci/cd: add codeowners file to set up auto assignment for frontend PR …

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,2 @@
+#This file defines the front end team as owners of this repo on Github so the auto assignment will work properly
+* @input-output-hk/frontend


### PR DESCRIPTION
Added a CODEOWNERS file to assign the frontend team in the IO repo to be the owner of the frontend repository. This should allow the auto assignment for PR to work. 

Reference docs:
[https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-code-review-settings](url)
[https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners](url)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Implemented a system for automatically assigning the front end team as the repository owners on GitHub for better management and workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->